### PR TITLE
Implementation of caching and check on file type

### DIFF
--- a/DurableFileProcessing/ActivityFunctions/GetEntityFromCache.cs
+++ b/DurableFileProcessing/ActivityFunctions/GetEntityFromCache.cs
@@ -21,7 +21,15 @@ namespace DurableFileProcessing.ActivityFunctions
         {
             string fileHash = context.GetInput<string>();
 
-            return await _cacheManager.GetEntityAsync("durablefileprocessing", fileHash);
+            var entity = await _cacheManager.GetEntityAsync("durablefileprocessing", fileHash);
+
+            if(entity == null)
+            {
+                log.LogDebug($"No entity for hash: {fileHash} found in cache.");
+            }
+
+            log.LogDebug($"Entity for hash: {fileHash} found in cache. File Status: {entity.FileStatus}, File Type: {entity.FileType}, TimeStamp: {entity.Timestamp}");
+            return entity;
         }
     }
 }

--- a/DurableFileProcessing/ActivityFunctions/GetEntityFromCache.cs
+++ b/DurableFileProcessing/ActivityFunctions/GetEntityFromCache.cs
@@ -1,0 +1,27 @@
+﻿using DurableFileProcessing.Interfaces;
+using DurableFileProcessing.Models;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+using Microsoft.Extensions.Logging;
+using System.Threading.Tasks;
+
+namespace DurableFileProcessing.ActivityFunctions
+{
+    public class GetEntityFromCache
+    {
+        private readonly ICacheManager<OutcomeEntity> _cacheManager;
+
+        public GetEntityFromCache(ICacheManager<OutcomeEntity> cacheManager)
+        {
+            _cacheManager = cacheManager;
+        }
+
+        [FunctionName("FileProcessing_GetEntityFromCache")]
+        public async Task<OutcomeEntity> Run([ActivityTrigger] IDurableActivityContext context, ILogger log)
+        {
+            string fileHash = context.GetInput<string>();
+
+            return await _cacheManager.GetEntityAsync("durablefileprocessing", fileHash);
+        }
+    }
+}

--- a/DurableFileProcessing/ActivityFunctions/GetEntityFromCache.cs
+++ b/DurableFileProcessing/ActivityFunctions/GetEntityFromCache.cs
@@ -27,8 +27,11 @@ namespace DurableFileProcessing.ActivityFunctions
             {
                 log.LogDebug($"No entity for hash: {fileHash} found in cache.");
             }
+            else
+            {
+                log.LogDebug($"Entity for hash: {fileHash} found in cache. File Status: {entity?.FileStatus}, File Type: {entity?.FileType}, TimeStamp: {entity?.Timestamp}");
+            }
 
-            log.LogDebug($"Entity for hash: {fileHash} found in cache. File Status: {entity.FileStatus}, File Type: {entity.FileType}, TimeStamp: {entity.Timestamp}");
             return entity;
         }
     }

--- a/DurableFileProcessing/ActivityFunctions/HashGenerator.cs
+++ b/DurableFileProcessing/ActivityFunctions/HashGenerator.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.IO;
 using System.Security.Cryptography;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace DurableFileProcessing.ActivityFunctions
@@ -24,7 +25,14 @@ namespace DurableFileProcessing.ActivityFunctions
 
                 fileStream.Position = 0;
 
-                return md5.ComputeHash(fileStream).ToString(); //lgtm [cs/call-to-object-tostring] Going to be reworked, not currently used
+                var hash = md5.ComputeHash(fileStream);
+
+                var stringBuilder = new StringBuilder();
+
+                foreach (byte b in hash)
+                    stringBuilder.AppendFormat("{0:X2}", b);
+
+                return stringBuilder.ToString();
             }
         }
     }

--- a/DurableFileProcessing/ActivityFunctions/InsertEntityIntoCache.cs
+++ b/DurableFileProcessing/ActivityFunctions/InsertEntityIntoCache.cs
@@ -1,0 +1,35 @@
+﻿using DurableFileProcessing.Interfaces;
+using DurableFileProcessing.Models;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+using Microsoft.Extensions.Logging;
+using System.Threading.Tasks;
+
+namespace DurableFileProcessing.ActivityFunctions
+{
+    public class InsertEntityIntoCache
+    {
+        private readonly ICacheManager<OutcomeEntity> _cacheManager;
+
+        public InsertEntityIntoCache(ICacheManager<OutcomeEntity> cacheManager)
+        {
+            _cacheManager = cacheManager;
+        }
+
+        [FunctionName("FileProcessing_InsertEntityIntoCache")]
+        public async Task Run([ActivityTrigger] IDurableActivityContext context, ILogger log)
+        {
+            (string fileHash, string fileStatus, string fileType) = context.GetInput<(string, string, string)>();
+
+            var entry = new OutcomeEntity
+            {
+                PartitionKey = "durablefileprocessing",
+                RowKey = fileHash,
+                FileStatus = fileStatus,
+                FileType = fileType
+            };
+
+            await _cacheManager.InsertEntityAsync(entry);
+        }
+    }
+}

--- a/DurableFileProcessing/Interfaces/ICacheClient.cs
+++ b/DurableFileProcessing/Interfaces/ICacheClient.cs
@@ -1,0 +1,7 @@
+﻿namespace DurableFileProcessing.Interfaces
+{
+    public interface ICacheClient<T>
+    {
+        T Client { get; }
+    }
+}

--- a/DurableFileProcessing/Interfaces/ICacheManager.cs
+++ b/DurableFileProcessing/Interfaces/ICacheManager.cs
@@ -1,0 +1,11 @@
+﻿using System.Threading.Tasks;
+
+namespace DurableFileProcessing.Interfaces
+{
+    public interface ICacheManager<T>
+    {
+        Task<T> GetEntityAsync(string partitionKey, string rowKey);
+
+        Task InsertEntityAsync(T entity);
+    }
+}

--- a/DurableFileProcessing/Interfaces/IConfigurationSettings.cs
+++ b/DurableFileProcessing/Interfaces/IConfigurationSettings.cs
@@ -3,8 +3,10 @@
     public interface IConfigurationSettings
     {
         string FileProcessingStorage { get; }
+        string CacheConnectionString { get; }
         string ServiceBusConnectionString { get; }
         string TransactionOutcomeQueueName { get; }
+        string TransactionOutcomeTableName { get; }
         string FiletypeDetectionUrl { get; }
         string FiletypeDetectionKey { get; }
         string RebuildUrl { get; }

--- a/DurableFileProcessing/Models/TransactionOutcomeEntity.cs
+++ b/DurableFileProcessing/Models/TransactionOutcomeEntity.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.Azure.Cosmos.Table;
+
+namespace DurableFileProcessing.Models
+{
+    public class OutcomeEntity : TableEntity
+    {
+        public OutcomeEntity(string function, string hash, string filetype, string filestatus)
+        {
+            this.PartitionKey = function;
+            this.RowKey = hash;
+            this.FileType = filetype;
+            this.FileStatus = filestatus;
+        }
+
+        public OutcomeEntity()
+        {
+
+        }
+
+        public string FileType { get; set; }
+
+        public string FileStatus { get; set; }
+    }
+}

--- a/DurableFileProcessing/Orchestrators/FileProcessingOrchestrator.cs
+++ b/DurableFileProcessing/Orchestrators/FileProcessingOrchestrator.cs
@@ -86,7 +86,10 @@ namespace DurableFileProcessing.Orchestrators
                 }
             }
 
-            await context.CallActivityAsync("FileProcessing_InsertEntityIntoCache", (hash, fileStatus.ToString(), filetype));
+            if (cachedEntry == null)
+            {
+                await context.CallActivityAsync("FileProcessing_InsertEntityIntoCache", (hash, fileStatus.ToString(), filetype));
+            }
         }
     }
 }

--- a/DurableFileProcessing/Orchestrators/FileProcessingOrchestrator.cs
+++ b/DurableFileProcessing/Orchestrators/FileProcessingOrchestrator.cs
@@ -31,22 +31,28 @@ namespace DurableFileProcessing.Orchestrators
             [Blob("original-store")] CloudBlobContainer container,
             ILogger log)
         {
+            ProcessingOutcome fileStatus;
+
             var blobName = context.GetInput<string>();
 
             string blobSas = _blobUtilities.GetSharedAccessSignature(container, blobName, context.CurrentUtcDateTime.AddHours(24), SharedAccessBlobPermissions.Read | SharedAccessBlobPermissions.Write);
             
             log.LogInformation($"FileProcessing SAS Token: {blobSas}");
 
-            var fileId = context.InstanceId.ToString();
+            var hash = await context.CallActivityAsync<string>("FileProcessing_HashGenerator", blobSas);
 
-            var filetype = await context.CallActivityAsync<string>("FileProcessing_GetFileType", (blobSas));
+            var cachedEntry = await context.CallActivityAsync<OutcomeEntity>("FileProcessing_GetEntityFromCache", hash);
 
+            var filetype = cachedEntry?.FileType ?? await context.CallActivityAsync<string>("FileProcessing_GetFileType", blobSas);
+            
             if (filetype == "error")
             {
+                fileStatus = ProcessingOutcome.Error;
                 await context.CallActivityAsync("FileProcessing_SignalTransactionOutcome", (blobName, new RebuildOutcome { Outcome = ProcessingOutcome.Error, RebuiltFileSas = String.Empty }));
             }
             else if (filetype == "unmanaged")
             {
+                fileStatus = ProcessingOutcome.Unknown;
                 await context.CallActivityAsync("FileProcessing_SignalTransactionOutcome", (blobName, new RebuildOutcome { Outcome = ProcessingOutcome.Unknown, RebuiltFileSas = String.Empty }));
             }
             else
@@ -61,22 +67,26 @@ namespace DurableFileProcessing.Orchestrators
                 var sourceSas = _blobUtilities.GetSharedAccessSignature(container, blobName, context.CurrentUtcDateTime.AddHours(24), SharedAccessBlobPermissions.Read);
 
                 // Specify the hash value as the rebuilt filename
-                var rebuiltWritesSas = _blobUtilities.GetSharedAccessSignature(rebuildContainer, fileId, context.CurrentUtcDateTime.AddHours(24), SharedAccessBlobPermissions.Write);
+                var rebuiltWritesSas = _blobUtilities.GetSharedAccessSignature(rebuildContainer, hash, context.CurrentUtcDateTime.AddHours(24), SharedAccessBlobPermissions.Write);
                 var rebuildOutcome = await context.CallActivityAsync<ProcessingOutcome>("FileProcessing_RebuildFile", (sourceSas, rebuiltWritesSas, filetype));
 
                 if (rebuildOutcome == ProcessingOutcome.Rebuilt)
                 {
-                    var rebuiltReadSas = _blobUtilities.GetSharedAccessSignature(rebuildContainer, fileId, context.CurrentUtcDateTime.AddHours(24), SharedAccessBlobPermissions.Read);
+                    fileStatus = ProcessingOutcome.Rebuilt;
+                    var rebuiltReadSas = _blobUtilities.GetSharedAccessSignature(rebuildContainer, hash, context.CurrentUtcDateTime.AddHours(24), SharedAccessBlobPermissions.Read);
                     log.LogInformation($"FileProcessing Rebuild {rebuiltReadSas}");
 
                     await context.CallActivityAsync("FileProcessing_SignalTransactionOutcome", (blobName, new RebuildOutcome { Outcome = ProcessingOutcome.Rebuilt, RebuiltFileSas = rebuiltReadSas }));
                 }
                 else
                 {
+                    fileStatus = ProcessingOutcome.Failed;
                     log.LogInformation($"FileProcessing Rebuild failure");
                     await context.CallActivityAsync("FileProcessing_SignalTransactionOutcome", (blobName, new RebuildOutcome { Outcome = ProcessingOutcome.Failed, RebuiltFileSas = String.Empty }));
                 }
             }
+
+            await context.CallActivityAsync("FileProcessing_InsertEntityIntoCache", (hash, fileStatus.ToString(), filetype));
         }
     }
 }

--- a/DurableFileProcessing/Services/AzureStorageAccount.cs
+++ b/DurableFileProcessing/Services/AzureStorageAccount.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.Azure.Storage;
-using DurableFileProcessing.Interfaces;
+﻿using DurableFileProcessing.Interfaces;
+using Microsoft.Azure.Storage;
 
 namespace DurableFileProcessing.Services
 {

--- a/DurableFileProcessing/Services/ConfigurationSettings.cs
+++ b/DurableFileProcessing/Services/ConfigurationSettings.cs
@@ -8,7 +8,9 @@ namespace DurableFileProcessing.Services
         public ConfigurationSettings()
         {
             FileProcessingStorage = Environment.GetEnvironmentVariable("FileProcessingStorage", EnvironmentVariableTarget.Process);
+            CacheConnectionString = Environment.GetEnvironmentVariable("CacheConnectionString", EnvironmentVariableTarget.Process);
             TransactionOutcomeQueueName = Environment.GetEnvironmentVariable("TransactionOutcomeQueueName", EnvironmentVariableTarget.Process);
+            TransactionOutcomeTableName = Environment.GetEnvironmentVariable("TransactionOutcomeTableName", EnvironmentVariableTarget.Process);
             FiletypeDetectionUrl = Environment.GetEnvironmentVariable("FiletypeDetectionUrl", EnvironmentVariableTarget.Process);
             ServiceBusConnectionString = Environment.GetEnvironmentVariable("ServiceBusConnectionString", EnvironmentVariableTarget.Process);
             FiletypeDetectionKey = Environment.GetEnvironmentVariable("FiletypeDetectionKey", EnvironmentVariableTarget.Process);
@@ -17,8 +19,10 @@ namespace DurableFileProcessing.Services
         }
 
         public string FileProcessingStorage { get; }
+        public string CacheConnectionString { get; }
         public string ServiceBusConnectionString { get; }
         public string TransactionOutcomeQueueName { get; }
+        public string TransactionOutcomeTableName { get; }
         public string FiletypeDetectionUrl { get; }
         public string FiletypeDetectionKey { get; }
         public string RebuildUrl { get; }

--- a/DurableFileProcessing/Services/TableStorageCacheClient.cs
+++ b/DurableFileProcessing/Services/TableStorageCacheClient.cs
@@ -1,0 +1,22 @@
+﻿using DurableFileProcessing.Interfaces;
+using Microsoft.Azure.Cosmos.Table;
+using System;
+
+namespace DurableFileProcessing.Services
+{
+    class TableStorageCacheClient : ICacheClient<CloudTableClient>
+    {
+        private Lazy<CloudTableClient> _cloudTableClient;
+        
+        public TableStorageCacheClient(IConfigurationSettings configurationSettings)
+        {
+            _cloudTableClient = new Lazy<CloudTableClient>(() =>
+            {
+                var cloudStorageAccount = CloudStorageAccount.Parse(configurationSettings.CacheConnectionString);
+                return cloudStorageAccount.CreateCloudTableClient();
+            });
+        }
+
+        public CloudTableClient Client => _cloudTableClient.Value;
+    }
+}

--- a/DurableFileProcessing/Services/TableStorageCacheManager.cs
+++ b/DurableFileProcessing/Services/TableStorageCacheManager.cs
@@ -1,0 +1,44 @@
+﻿using DurableFileProcessing.Interfaces;
+using DurableFileProcessing.Models;
+using Microsoft.Azure.Cosmos.Table;
+using System.Threading.Tasks;
+
+namespace DurableFileProcessing.Services
+{
+    public class TableStorageCacheManager : ICacheManager<OutcomeEntity>
+    {
+        private readonly ICacheClient<CloudTableClient> _cacheClient;
+        private readonly IConfigurationSettings _configurationSettings;
+
+        public TableStorageCacheManager(ICacheClient<CloudTableClient> cacheClient, IConfigurationSettings configurationSettings)
+        {
+            _cacheClient = cacheClient;
+            _configurationSettings = configurationSettings;
+        }
+
+        public async Task<OutcomeEntity> GetEntityAsync(string partitionKey, string rowKey)
+        {
+            var table = _cacheClient.Client.GetTableReference(_configurationSettings.TransactionOutcomeTableName);
+
+            var retrieveOperation = TableOperation.Retrieve<OutcomeEntity>(partitionKey, rowKey);
+
+            var result = await table.ExecuteAsync(retrieveOperation);
+
+            if (result == null)
+            {
+                return null;
+            }
+
+            return result.Result as OutcomeEntity;
+        }
+
+        public async Task InsertEntityAsync(OutcomeEntity entity)
+        {
+            var table = _cacheClient.Client.GetTableReference(_configurationSettings.TransactionOutcomeTableName);
+
+            var insertOperation = TableOperation.InsertOrMerge(entity);
+
+            await table.ExecuteAsync(insertOperation);
+        }
+    }
+}

--- a/DurableFileProcessing/Services/TableStorageCacheManager.cs
+++ b/DurableFileProcessing/Services/TableStorageCacheManager.cs
@@ -18,7 +18,7 @@ namespace DurableFileProcessing.Services
 
         public async Task<OutcomeEntity> GetEntityAsync(string partitionKey, string rowKey)
         {
-            var table = _cacheClient.Client.GetTableReference(_configurationSettings.TransactionOutcomeTableName);
+            var table = _cacheClient.Client.GetTableReference(_configurationSettings.CacheConnectionString);
 
             var retrieveOperation = TableOperation.Retrieve<OutcomeEntity>(partitionKey, rowKey);
 
@@ -34,7 +34,7 @@ namespace DurableFileProcessing.Services
 
         public async Task InsertEntityAsync(OutcomeEntity entity)
         {
-            var table = _cacheClient.Client.GetTableReference(_configurationSettings.TransactionOutcomeTableName);
+            var table = _cacheClient.Client.GetTableReference(_configurationSettings.CacheConnectionString);
 
             var insertOperation = TableOperation.InsertOrMerge(entity);
 

--- a/DurableFileProcessing/Startup.cs
+++ b/DurableFileProcessing/Startup.cs
@@ -14,6 +14,8 @@ namespace DurableFileProcessing
             builder.Services.AddTransient(typeof(IMessageClient<>), typeof(AzureServiceBusClient));
             builder.Services.AddTransient(typeof(IStorageAccount<>), typeof(AzureStorageAccount));
             builder.Services.AddSingleton<IConfigurationSettings, ConfigurationSettings>();
+            builder.Services.AddSingleton(typeof(ICacheClient<>), typeof(TableStorageCacheClient));
+            builder.Services.AddTransient(typeof(ICacheManager<>), typeof(TableStorageCacheManager));
         }
     }
 }

--- a/DurableFileProcessing/local.settings.json
+++ b/DurableFileProcessing/local.settings.json
@@ -3,7 +3,9 @@
   "Values": {
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FileProcessingStorage": "--SECRET--",
+    "CacheConnectionString": "--SECRET--",
     "ServiceBusConnectionString": "--SECRET--",
+    "TransactionOutcomeTableName": "filestatuscache",
     "TransactionOutcomeQueueName": "transaction-outcome",
     "FiletypeDetectionUrl": "https://fglpdf9gf6.execute-api.us-west-2.amazonaws.com/Prod/api/FileTypeDetection/sas",
     "FiletypeDetectionKey": "--SECRET--",

--- a/Tests/DurableFileProcessing.Tests/ActivityFunctions/GetEntityFromCacheTests.cs
+++ b/Tests/DurableFileProcessing.Tests/ActivityFunctions/GetEntityFromCacheTests.cs
@@ -1,0 +1,55 @@
+﻿using DurableFileProcessing.ActivityFunctions;
+using DurableFileProcessing.Interfaces;
+using DurableFileProcessing.Models;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using System.Threading.Tasks;
+
+namespace DurableFileProcessing.Tests.ActivityFunctions
+{
+    public class GetEntityFromCacheTests
+    {
+        public class RunMethod : GetEntityFromCacheTests
+        {
+            [Test]
+            public async Task Entity_Is_Returned_When_Called()
+            {
+                // Arrange
+                const string fileHash = "IAMHASH";
+                const string partitionKey = "durablefileprocessing";
+
+                var expected = new OutcomeEntity
+                {
+                    FileStatus = "rebuilt",
+                    FileType = "Pdf",
+                    RowKey = fileHash,
+                    PartitionKey = "durablefileprocessing"
+                };
+
+                var mockCacheManager = new Mock<ICacheManager<OutcomeEntity>>();
+                var mockContext = new Mock<IDurableActivityContext>();
+                var mockLogger = new Mock<ILogger>();
+
+                mockCacheManager.Setup(s => s.GetEntityAsync(
+                    It.Is<string>(name => name == partitionKey),
+                    It.Is<string>(hash => hash == fileHash)))
+                    .ReturnsAsync(expected);
+
+                mockContext.Setup(s => s.GetInput<string>()).Returns(fileHash);
+
+                var activityFunction = new GetEntityFromCache(mockCacheManager.Object);
+
+                // Act
+                var result = await activityFunction.Run(mockContext.Object, mockLogger.Object);
+
+                // Assert
+                Assert.That(result.FileType, Is.EqualTo(expected.FileType));
+                Assert.That(result.FileStatus, Is.EqualTo(expected.FileStatus));
+                Assert.That(result.RowKey, Is.EqualTo(expected.RowKey));
+                Assert.That(result.PartitionKey, Is.EqualTo(expected.PartitionKey));
+            }
+        }
+    }
+}

--- a/Tests/DurableFileProcessing.Tests/ActivityFunctions/InsertEntityIntoCacheTests.cs
+++ b/Tests/DurableFileProcessing.Tests/ActivityFunctions/InsertEntityIntoCacheTests.cs
@@ -1,0 +1,51 @@
+﻿using DurableFileProcessing.ActivityFunctions;
+using DurableFileProcessing.Interfaces;
+using DurableFileProcessing.Models;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using System.Threading.Tasks;
+
+namespace DurableFileProcessing.Tests.ActivityFunctions
+{
+    public class InsertEntityIntoCacheTests
+    {
+        public class RunMethod : InsertEntityIntoCacheTests
+        {
+            [Test]
+            public async Task Entity_Is_Inserted_When_Called()
+            {
+                // Arrange
+                const string fileHash = "IAMHASH";
+                const string fileStatus = "rebuilt";
+                const string fileType = "pdf";
+                const string partitionKey = "durablefileprocessing";
+
+                var actual = new OutcomeEntity();
+
+                var mockCacheManager = new Mock<ICacheManager<OutcomeEntity>>();
+                var mockContext = new Mock<IDurableActivityContext>();
+                var mockLogger = new Mock<ILogger>();
+
+                mockContext.Setup(s => s.GetInput<(string, string, string)>()).Returns((fileHash, fileStatus, fileType));
+
+                mockCacheManager.Setup(s => s.InsertEntityAsync(It.IsAny<OutcomeEntity>())).Callback<OutcomeEntity>((entity) =>
+                {
+                    actual = entity;
+                });
+
+                var activityFunction = new InsertEntityIntoCache(mockCacheManager.Object);
+
+                // Act
+                await activityFunction.Run(mockContext.Object, mockLogger.Object);
+
+                // Assert
+                Assert.That(actual.FileType, Is.EqualTo(fileType));
+                Assert.That(actual.FileStatus, Is.EqualTo(fileStatus));
+                Assert.That(actual.RowKey, Is.EqualTo(fileHash));
+                Assert.That(actual.PartitionKey, Is.EqualTo(partitionKey));
+            }
+        }
+    }
+}

--- a/Tests/DurableFileProcessing.Tests/Orchestrators/FileProcessingTests.cs
+++ b/Tests/DurableFileProcessing.Tests/Orchestrators/FileProcessingTests.cs
@@ -23,8 +23,7 @@ namespace DurableFileProcessing.Tests
             private const string SourceReadSas = "SourceReadSas";
             private const string RebuiltWriteSas = "RebuiltWriteSas";
             private const string RebuiltReadSas = "RebuiltReadSas";
-
-            private string _instanceId = Guid.NewGuid().ToString();
+            private const string FileHash = "FileHash";
 
             private CloudBlobContainer _cloudBlobContainer;
 
@@ -56,11 +55,15 @@ namespace DurableFileProcessing.Tests
                 _mockCloudStorageAccount = new Mock<CloudStorageAccount>(new StorageCredentials("dummyAccountName", "dummykey"), false);
 
                 _mockContext.Setup(s => s.GetInput<string>()).Returns(BlobName);
-                _mockContext.SetupGet(s => s.InstanceId).Returns(_instanceId);
+                _mockContext.SetupGet(s => s.InstanceId).Returns(FileHash);
+                _mockContext.Setup(s => s.CallActivityAsync<string>(
+                    It.Is<string>(s => s == "FileProcessing_HashGenerator"),
+                    It.IsAny<object>()))
+                    .ReturnsAsync(FileHash);
 
                 _mockBlobUtilities.Setup(s => s.GetSharedAccessSignature(
                     It.IsAny<CloudBlobContainer>(),
-                    It.Is<string>(s => s == _instanceId),
+                    It.Is<string>(s => s == FileHash),
                     It.IsAny<DateTimeOffset>(),
                     It.Is<SharedAccessBlobPermissions>(s => s.Equals(SharedAccessBlobPermissions.Read))))
                     .Returns(RebuiltReadSas);
@@ -74,7 +77,7 @@ namespace DurableFileProcessing.Tests
 
                 _mockBlobUtilities.Setup(s => s.GetSharedAccessSignature(
                     It.IsAny<CloudBlobContainer>(), 
-                    It.Is<string>(s => s == _instanceId), 
+                    It.Is<string>(s => s == FileHash), 
                     It.IsAny<DateTimeOffset>(),
                     It.Is<SharedAccessBlobPermissions>(s => s.Equals(SharedAccessBlobPermissions.Write))))
                     .Returns(RebuiltWriteSas);
@@ -93,7 +96,119 @@ namespace DurableFileProcessing.Tests
             }
 
             [Test]
-            public async Task When_FileProcessing_Returns_Error_ErrorTransactionOutcome_Is_Signaled()
+            public async Task When_Hash_Is_Found_In_Cache_GetFileType_IsNot_Called()
+            {
+                // Arrange
+                _mockContext.Setup(s => s.CallActivityAsync<OutcomeEntity>(
+                    It.Is<string>(s => s == "FileProcessing_GetEntityFromCache"),
+                    It.IsAny<object>()))
+                    .ReturnsAsync(new OutcomeEntity
+                    {
+                        FileType = "docx"
+                    });
+
+                // Act
+                await _fileProcessingOrchestrator.RunOrchestrator(_mockContext.Object, _cloudBlobContainer, _mockLogger.Object);
+
+                // Assert
+                _mockContext.Verify(s => s.CallActivityAsync<string>(
+                    It.Is<string>(s => s == "FileProcessing_GetFileType"),
+                    It.IsAny<object>()), Times.Never);
+            }
+
+            [Test]
+            public async Task When_Hash_IsNot_Found_In_Cache_GetFileType_Is_Called()
+            {
+                // Arrange
+                _mockContext.Setup(s => s.CallActivityAsync<OutcomeEntity>(
+                    It.Is<string>(s => s == "FileProcessing_GetEntityFromCache"),
+                    It.IsAny<object>()))
+                    .ReturnsAsync((OutcomeEntity)null);
+
+                // Act
+                await _fileProcessingOrchestrator.RunOrchestrator(_mockContext.Object, _cloudBlobContainer, _mockLogger.Object);
+
+                // Assert
+                _mockContext.Verify(s => s.CallActivityAsync<string>(
+                    It.Is<string>(s => s == "FileProcessing_GetFileType"),
+                    It.IsAny<object>()), Times.Once);
+            }
+
+            [Test]
+            public async Task When_Hash_IsNot_Found_In_Cache_InsertEntityIntoCache_Is_Called()
+            {
+                // Arrange
+                const string expectedFileType = "docx";
+                var expectedProcessingStatus = ProcessingOutcome.Rebuilt;
+
+                string actualFileHash = string.Empty;
+                string actualFileStatus = string.Empty;
+                string actualFileType = string.Empty;
+
+                _mockContext.Setup(s => s.CallActivityAsync<OutcomeEntity>(
+                    It.Is<string>(s => s == "FileProcessing_GetEntityFromCache"),
+                    It.IsAny<object>()))
+                    .ReturnsAsync((OutcomeEntity)null);
+
+                _mockContext.Setup(s => s.CallActivityAsync<string>(
+                    It.Is<string>(s => s == "FileProcessing_GetFileType"),
+                    It.IsAny<object>()))
+                    .ReturnsAsync(expectedFileType);
+
+                _mockContext.Setup(s => s.CallActivityAsync<ProcessingOutcome>(
+                    It.Is<string>(s => s == "FileProcessing_RebuildFile"),
+                    It.IsAny<object>()))
+                    .ReturnsAsync(expectedProcessingStatus);
+
+                _mockContext.Setup(s => s.CallActivityAsync<object>(
+                    It.Is<string>(s => s == "FileProcessing_InsertEntityIntoCache"),
+                    It.IsAny<object>()))
+                .Callback<string, object>((s, obj) =>
+                {
+                    actualFileHash = (string)obj.GetType().GetField("Item1").GetValue(obj);
+                    actualFileStatus = (string)obj.GetType().GetField("Item2").GetValue(obj);
+                    actualFileType = (string)obj.GetType().GetField("Item3").GetValue(obj);
+}               );
+
+                // Act
+                await _fileProcessingOrchestrator.RunOrchestrator(_mockContext.Object, _cloudBlobContainer, _mockLogger.Object);
+
+                // Assert
+                Assert.That(actualFileHash, Is.EqualTo(FileHash));
+                Assert.That(actualFileStatus, Is.EqualTo(expectedProcessingStatus.ToString()));
+                Assert.That(actualFileType, Is.EqualTo(expectedFileType));
+            }
+
+            [Test]
+            public async Task When_Hash_Is_Found_In_Cache_InsertEntityIntoCache_IsNot_Called()
+            {
+                // Arrange
+                var expectedProcessingStatus = ProcessingOutcome.Rebuilt;
+                
+                _mockContext.Setup(s => s.CallActivityAsync<OutcomeEntity>(
+                    It.Is<string>(s => s == "FileProcessing_GetEntityFromCache"),
+                    It.IsAny<object>()))
+                    .ReturnsAsync(new OutcomeEntity
+                    {
+                        FileType = "docx"
+                    });
+
+                _mockContext.Setup(s => s.CallActivityAsync<ProcessingOutcome>(
+                    It.Is<string>(s => s == "FileProcessing_RebuildFile"),
+                    It.IsAny<object>()))
+                    .ReturnsAsync(expectedProcessingStatus);
+
+                // Act
+                await _fileProcessingOrchestrator.RunOrchestrator(_mockContext.Object, _cloudBlobContainer, _mockLogger.Object);
+
+                // Assert
+                _mockContext.Verify(s => s.CallActivityAsync<object>(
+                    It.Is<string>(s => s == "FileProcessing_InsertEntityIntoCache"),
+                    It.IsAny<object>()), Times.Never);
+            }
+
+            [Test]
+            public async Task When_GetFileType_Returns_Error_ErrorTransactionOutcome_Is_Signaled()
             {
                 // Arrange
                 RebuildOutcome actualOutcome = null;
@@ -129,7 +244,7 @@ namespace DurableFileProcessing.Tests
             }
 
             [Test]
-            public async Task When_FileProcessing_Returns_Unmanaged_UnknownTransactionOutcome_Is_Signaled()
+            public async Task When_GetFileType_Returns_Unmanaged_UnknownTransactionOutcome_Is_Signaled()
             {
                 // Arrange
                 RebuildOutcome actualOutcome = null;

--- a/Tests/DurableFileProcessing.Tests/Services/TableStorageCacheManagerTests.cs
+++ b/Tests/DurableFileProcessing.Tests/Services/TableStorageCacheManagerTests.cs
@@ -1,0 +1,138 @@
+﻿using DurableFileProcessing.Interfaces;
+using DurableFileProcessing.Models;
+using DurableFileProcessing.Services;
+using Microsoft.Azure.Cosmos.Table;
+using Moq;
+using NUnit.Framework;
+using System;
+using System.Threading.Tasks;
+
+namespace DurableFileProcessing.Tests.Services
+{
+    public class TableStorageCacheManagerTests
+    {
+        public class GetEntityAsyncMethod : TableStorageCacheManagerTests
+        {
+            private const string ConnectionString = "ConnectionString";
+
+            private Mock<ICacheClient<CloudTableClient>> _mockCacheClient;
+            private Mock<IConfigurationSettings> _mockConfigurationSettings;
+
+            private Mock<CloudTableClient> _mockCloudTableClient;
+            private Mock<CloudTable> _mockCloudTable;
+
+            [SetUp]
+            public void SetUp()
+            {
+                _mockCacheClient = new Mock<ICacheClient<CloudTableClient>>();
+                _mockConfigurationSettings = new Mock<IConfigurationSettings>();
+                _mockCloudTableClient = new Mock<CloudTableClient>(new Uri("http://localhost"), new StorageCredentials(accountName: "blah", keyValue: "blah"), (TableClientConfiguration)null);
+
+                _mockCloudTable = new Mock<CloudTable>(new Uri("http://tableaddress.org"), (TableClientConfiguration)null);
+
+                _mockConfigurationSettings.SetupGet(s => s.CacheConnectionString).Returns(ConnectionString);
+
+                _mockCacheClient.SetupGet(s => s.Client).Returns(_mockCloudTableClient.Object);
+
+                _mockCloudTableClient.Setup(s => s.GetTableReference(It.Is<string>(s => s == ConnectionString))).Returns(_mockCloudTable.Object);
+            }
+
+            [Test]
+            public async Task Null_Is_Returned_When_Entity_IsNot_Found()
+            {
+                // Arrange
+                _mockCloudTable.Setup(s => s.ExecuteAsync(It.IsAny<TableOperation>())).ReturnsAsync((TableResult)null);
+
+                var cacheManager = new TableStorageCacheManager(_mockCacheClient.Object, _mockConfigurationSettings.Object);
+
+                // Act
+                var result = await cacheManager.GetEntityAsync("partitionKey", "rowKey");
+
+                // Assert
+                Assert.That(result, Is.Null);
+            }
+
+            [Test]
+            public async Task Result_Is_Returned_When_Entity_Is_Found()
+            {
+                // Arrange
+                var expected = new OutcomeEntity
+                {
+                    FileType = "docx",
+                    FileStatus = "rebuilt",
+                    RowKey = "1234567"
+                };
+
+                _mockCloudTable.Setup(s => s.ExecuteAsync(It.IsAny<TableOperation>())).ReturnsAsync(new TableResult { Result = expected });
+
+                var cacheManager = new TableStorageCacheManager(_mockCacheClient.Object, _mockConfigurationSettings.Object);
+
+                // Act
+                var result = await cacheManager.GetEntityAsync("partitionKey", "rowKey");
+
+                // Assert
+                Assert.That(result.FileType, Is.EqualTo(expected.FileType));
+                Assert.That(result.FileStatus, Is.EqualTo(expected.FileStatus));
+                Assert.That(result.RowKey, Is.EqualTo(expected.RowKey));
+            }
+        }
+
+        public class InsertEntityAsyncMethod : TableStorageCacheManagerTests
+        {
+            private const string ConnectionString = "ConnectionString";
+
+            private Mock<ICacheClient<CloudTableClient>> _mockCacheClient;
+            private Mock<IConfigurationSettings> _mockConfigurationSettings;
+
+            private Mock<CloudTableClient> _mockCloudTableClient;
+            private Mock<CloudTable> _mockCloudTable;
+
+            [SetUp]
+            public void SetUp()
+            {
+                _mockCacheClient = new Mock<ICacheClient<CloudTableClient>>();
+                _mockConfigurationSettings = new Mock<IConfigurationSettings>();
+                _mockCloudTableClient = new Mock<CloudTableClient>(new Uri("http://localhost"), new StorageCredentials(accountName: "blah", keyValue: "blah"), (TableClientConfiguration)null);
+
+                _mockCloudTable = new Mock<CloudTable>(new Uri("http://tableaddress.org"), (TableClientConfiguration)null);
+
+                _mockConfigurationSettings.SetupGet(s => s.CacheConnectionString).Returns(ConnectionString);
+
+                _mockCacheClient.SetupGet(s => s.Client).Returns(_mockCloudTableClient.Object);
+
+                _mockCloudTableClient.Setup(s => s.GetTableReference(It.Is<string>(s => s == ConnectionString))).Returns(_mockCloudTable.Object);
+            }
+
+            [Test]
+            public async Task Correct_Entity_Is_Inserted_When_Called()
+            {
+                // Arrange
+                var expected = new OutcomeEntity
+                {
+                    FileType = "docx",
+                    FileStatus = "rebuilt",
+                    RowKey = "1234567",
+                    PartitionKey = "durablefileprocessing"
+                };
+
+                OutcomeEntity actualEntity = null;
+
+                _mockCloudTable.Setup(s => s.ExecuteAsync(It.IsAny<TableOperation>())).Callback<TableOperation>((op) =>
+                {
+                    actualEntity = (OutcomeEntity)op.Entity;
+                });
+
+                var cacheManager = new TableStorageCacheManager(_mockCacheClient.Object, _mockConfigurationSettings.Object);
+
+                // Act
+                await cacheManager.InsertEntityAsync(expected);
+
+                // Assert
+                Assert.That(actualEntity.FileType, Is.EqualTo(expected.FileType));
+                Assert.That(actualEntity.FileStatus, Is.EqualTo(expected.FileStatus));
+                Assert.That(actualEntity.RowKey, Is.EqualTo(expected.RowKey));
+                Assert.That(actualEntity.PartitionKey, Is.EqualTo(expected.PartitionKey));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implementation of caching via Table Storage. Then using the cache to check if the file hash has already been seen, if it has, use the determined File Type instead of calling the API.

closes #24 